### PR TITLE
feat: Add optional cli arg

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,6 @@
+import argparse
 import os
+from pathlib import Path
 import sys
 import json
 import time
@@ -39,8 +41,11 @@ class Handler(QObject):
 #.\photoLocationUpdaterEnv\Scripts\activate
 class Window(QMainWindow, Ui_MainWindow):
     
-    def __init__(self):
+    def __init__(self, photo_dir: Path | None = None):
         super().__init__()
+
+        self.photo_dir: Path | None = photo_dir
+
         self.setupUi(self)
 
         QImageReader.setAllocationLimit(0)
@@ -949,9 +954,14 @@ class Window(QMainWindow, Ui_MainWindow):
             return f"The calculated location differs from the photos taken date by {int(minutes):02d} minutes."
   
 
-app = QApplication(sys.argv)
-window = Window()
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(prog='photo-location-setter', usage='%(prog)s [dir]')
+    parser.add_argument('dir', nargs='?', help='Directory containing fotos to edit location information [optional].')
+    args = parser.parse_args()
 
-app.setStyle("Fusion")
-window.show()
-app.exec()
+    app = QApplication(sys.argv)
+    app.setStyle('Fusion')
+
+    window = Window(Path(args.dir))
+    window.show()
+    app.exec()


### PR DESCRIPTION
Goal: Having the possibility to provide the directory via commandline accelerates testing and debugging because no manual folder selection is possible. And it makes photo-location-updater integrable with shell scripts.

State 2026-05-20: The CLI arg can be provided but due to my lack of PyQt knowledge, I dont know how to "open" the folder on startup. @Rick45, I hope you know how to finish this PR easily.

Maybe you have to accept/merge this PR before you can work on this. If you have questions/problems, let me know!

